### PR TITLE
DHFPROD-7166: Update to work with DH 5.4.2

### DIFF
--- a/middle-tier/build.gradle
+++ b/middle-tier/build.gradle
@@ -61,7 +61,7 @@ dependencies {
 	// No idea why this is necessary, but when Gradle brings the core project over, it bumps the okhttp3 dependency
 	// down from 4.4.0 to 3.x, which then breaks all kinds of stuff. So exclude the two okhttp3 dependencies and
 	// then explicitly depending on the desired versions.
-	implementation ("com.marklogic:marklogic-data-hub:5.4.1") {
+	implementation ("com.marklogic:marklogic-data-hub:5.4.2") {
 		exclude group: "com.squareup.okhttp3", module: "okhttp"
 		exclude group: "com.squareup.okhttp3", module: "logging-interceptor"
 	}

--- a/middle-tier/src/main/resources/envision-modules/root/envision/dh-utils.sjs
+++ b/middle-tier/src/main/resources/envision-modules/root/envision/dh-utils.sjs
@@ -1,0 +1,10 @@
+const DataHub = require("/data-hub/5/datahub.sjs")
+const datahub = new DataHub()
+
+const jobs = datahub.jobs ? datahub.jobs : require('/data-hub/5/impl/jobs.sjs');
+const hubUtils = datahub.hubUtils ? datahub.hubUtils : require('/data-hub/5/impl/hub-utils.sjs');
+
+module.exports = {
+	jobs,
+	hubUtils
+}

--- a/middle-tier/src/main/resources/envision-modules/root/envision/jobs/deleteJob.sjs
+++ b/middle-tier/src/main/resources/envision-modules/root/envision/jobs/deleteJob.sjs
@@ -1,8 +1,7 @@
 'use strict'
 var jobId
 
-const DataHub = require("/data-hub/5/datahub.sjs")
-const datahub = new DataHub()
+const datahub = require("/envision/dh-utils.sjs")
 
 datahub.jobs.deleteJob(jobId)
 

--- a/middle-tier/src/main/resources/envision-modules/root/envision/jobs/getJobs.sjs
+++ b/middle-tier/src/main/resources/envision-modules/root/envision/jobs/getJobs.sjs
@@ -1,7 +1,6 @@
 'use strict'
 var flowName
 
-const DataHub = require("/data-hub/5/datahub.sjs")
-const datahub = new DataHub()
+const datahub = require("/envision/dh-utils.sjs")
 
 datahub.jobs.getJobDocsByFlow(flowName)

--- a/middle-tier/src/main/resources/envision-modules/root/envision/mastering/merge.sjs
+++ b/middle-tier/src/main/resources/envision-modules/root/envision/mastering/merge.sjs
@@ -9,6 +9,7 @@ var performanceMetrics;
 
 uris = uris.toObject();
 const DataHubSingleton = require("/data-hub/5/datahub-singleton.sjs");
+const dhUtils = require("/envision/dh-utils.sjs")
 const mastering = require('/envision/mastering.sjs')
 
 if (!preview && mastering.isBlocked(uris).blocked) {
@@ -52,7 +53,7 @@ else {
 	combinedOptions.noWrite = !!preview;
 	combinedOptions.acceptsBatch = true;
 	let query = cts.documentQuery(uris);
-	let content = datahub.hubUtils.queryToContentDescriptorArray(query, combinedOptions, sourceDatabase);
+	let content = dhUtils.hubUtils.queryToContentDescriptorArray(query, combinedOptions, sourceDatabase);
 	let results = datahub.flow.runFlow(internalFlowName, jobId, content, combinedOptions, internalStepNumber);
 	const response = {
 		'success': results.errorCount === 0,


### PR DESCRIPTION
Upgrades the dependency to DH 5.4.2 and create a util library that will allow function calls to work with both Data Hub 5.4.1 and 5.4.2