### PR TITLE
DHFPROD-7166: Ensure modules are installed for tests

### DIFF
--- a/middle-tier/src/test/java/com/marklogic/envision/FlowServiceTest.java
+++ b/middle-tier/src/test/java/com/marklogic/envision/FlowServiceTest.java
@@ -25,12 +25,10 @@ public class FlowServiceTest extends BaseTest {
 
 	@BeforeEach
 	void setUp() throws IOException {
-		removeUser(ACCOUNT_NAME);
 		clearStagingFinalAndJobDatabases();
-		clearDatabases(HubConfig.DEFAULT_MODULES_DB_NAME);
-
-		installHubModules();
-		installEnvisionModules();
+		clearModules();
+		super.setup();
+		removeUser(ACCOUNT_NAME);
 
 		registerAccount();
 

--- a/middle-tier/src/test/java/com/marklogic/envision/GetSampleDocTest.java
+++ b/middle-tier/src/test/java/com/marklogic/envision/GetSampleDocTest.java
@@ -12,9 +12,9 @@ public class GetSampleDocTest extends BaseTest {
 
 	@BeforeEach
 	void setUp() throws IOException {
+		super.setup();
 		removeUser(ACCOUNT_NAME);
 		clearStagingFinalAndJobDatabases();
-		installEnvisionModules();
 
 		registerAccount();
 

--- a/middle-tier/src/test/java/com/marklogic/envision/MasteringTest.java
+++ b/middle-tier/src/test/java/com/marklogic/envision/MasteringTest.java
@@ -30,10 +30,9 @@ public class MasteringTest extends BaseTest {
 	@BeforeEach
 	void setUp() throws IOException, InterruptedException {
 		envisionConfig.setMultiTenant(true);
+		super.setup();
 		removeUser(ACCOUNT_NAME);
 		clearStagingFinalAndJobDatabases();
-
-		installEnvisionModules();
 
 		registerAccount();
 

--- a/middle-tier/src/test/java/com/marklogic/envision/ModelTests.java
+++ b/middle-tier/src/test/java/com/marklogic/envision/ModelTests.java
@@ -37,17 +37,19 @@ public class ModelTests extends BaseTest {
 	@Autowired
 	SessionManager sessionManager;
 
+	private boolean modulesInstalled = false;
+
 	@BeforeEach
 	void setUp() throws Exception {
+		envisionConfig.setMultiTenant(false);
+		super.setup();
 		deleteProtectedPaths(getAdminHubClient().getFinalClient());
 
 		removeUser(ACCOUNT_NAME);
 
-		envisionConfig.setMultiTenant(false);
 
 		clearStagingFinalAndJobDatabases();
 		clearDatabases(HubConfig.DEFAULT_FINAL_SCHEMAS_DB_NAME);
-		installEnvisionModules();
 
 		registerAccount();
 		sessionManager.setHubClient(ACCOUNT_NAME, getAdminHubClient());

--- a/middle-tier/src/test/java/com/marklogic/envision/Search.java
+++ b/middle-tier/src/test/java/com/marklogic/envision/Search.java
@@ -51,11 +51,10 @@ public class Search extends BaseTest {
 
 	private void localSetUp(boolean isMultiTenant) throws IOException {
 		envisionConfig.setMultiTenant(isMultiTenant);
+		super.setup();
 		removeUser(ACCOUNT_NAME);
 		clearStagingFinalAndJobDatabases();
 		clearDatabases(HubConfig.DEFAULT_STAGING_SCHEMAS_DB_NAME, HubConfig.DEFAULT_FINAL_SCHEMAS_DB_NAME);
-
-		installEnvisionModules();
 
 		registerAccount();
 

--- a/middle-tier/src/test/java/com/marklogic/envision/SystemUtilsTest.java
+++ b/middle-tier/src/test/java/com/marklogic/envision/SystemUtilsTest.java
@@ -10,15 +10,17 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import java.io.IOException;
+
 @SpringBootTest
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = Application.class)
 public class SystemUtilsTest extends BaseTest {
 
 	@BeforeEach
-	void setUp() {
+	void setUp() throws IOException {
+		super.setup();
 		clearStagingFinalAndJobDatabases();
-		installEnvisionModules();
 	}
 
 	@Test

--- a/middle-tier/src/test/java/com/marklogic/envision/TestBrowseTriples.java
+++ b/middle-tier/src/test/java/com/marklogic/envision/TestBrowseTriples.java
@@ -25,11 +25,10 @@ public class TestBrowseTriples extends BaseTest {
 	@BeforeEach
 	void setUp() throws IOException {
 		envisionConfig.setMultiTenant(true);
+		super.setup();
 		removeUser(ACCOUNT_NAME);
 		clearStagingFinalAndJobDatabases();
 		clearDatabases(HubConfig.DEFAULT_STAGING_SCHEMAS_DB_NAME, HubConfig.DEFAULT_FINAL_SCHEMAS_DB_NAME);
-
-		installEnvisionModules();
 
 		registerAccount();
 

--- a/middle-tier/src/test/java/com/marklogic/envision/UploadServiceTest.java
+++ b/middle-tier/src/test/java/com/marklogic/envision/UploadServiceTest.java
@@ -44,7 +44,8 @@ public class UploadServiceTest extends BaseTest {
 	private LoadHubArtifactsCommand loadHubArtifactsCommand;
 
 	@BeforeEach
-	void setup() throws IOException {
+	public void setup() throws IOException {
+		super.setup();
 		removeUser(ACCOUNT_NAME);
 		clearStagingFinalAndJobDatabases();
 		clearDatabases(HubConfig.DEFAULT_STAGING_SCHEMAS_DB_NAME, HubConfig.DEFAULT_FINAL_SCHEMAS_DB_NAME);

--- a/middle-tier/src/test/java/com/marklogic/envision/controllers/AbstractMvcTest.java
+++ b/middle-tier/src/test/java/com/marklogic/envision/controllers/AbstractMvcTest.java
@@ -30,6 +30,11 @@ public class AbstractMvcTest extends BaseTest {
 
 	protected String authToken;
 
+	public void setup() throws IOException {
+		super.setup();
+		logout();
+	}
+
 	protected String buildLoginPayload(String username, String password) {
 		LoginInfo loginInfo = new LoginInfo();
 		loginInfo.username = username;

--- a/middle-tier/src/test/java/com/marklogic/envision/controllers/AuthenticationTests.java
+++ b/middle-tier/src/test/java/com/marklogic/envision/controllers/AuthenticationTests.java
@@ -15,6 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.URLEncoder;
 import java.util.Calendar;
 import java.util.Date;
@@ -39,23 +40,18 @@ public class AuthenticationTests extends AbstractMvcTest {
 	private static final String SAVE_MODEL_URL = "/api/models/";
 	private static final String CREATE_STEP_URL = "/api/flows/steps";
 
-	private boolean modulesInstalled = false;
-
 	@Autowired
 	ModelService modelService;
 
 	@Autowired
 	FlowsService flowsService;
 	@BeforeEach
-	void setup() {
-		if (!modulesInstalled) {
-			installEnvisionModules();
-			modulesInstalled = true;
-		}
+	public void setup() throws IOException {
+		envisionConfig.setMultiTenant(true);
+		super.setup();
 		removeUser(ACCOUNT_NAME);
 		removeUser(ADMIN_ACCOUNT_NAME);
 		removeUser(ACCOUNT_NAME2);
-		envisionConfig.setMultiTenant(true);
 
 		// remove models
 		File modelDir = modelService.getModelsDir(true, ACCOUNT_NAME);
@@ -64,7 +60,6 @@ public class AuthenticationTests extends AbstractMvcTest {
 		}
 		clearStagingFinalAndJobDatabases();
 		clearDatabases(HubConfig.DEFAULT_FINAL_SCHEMAS_DB_NAME, HubConfig.DEFAULT_STAGING_SCHEMAS_DB_NAME);
-		installEnvisionModules();
 	}
 
 	@Test

--- a/middle-tier/src/test/java/com/marklogic/envision/controllers/CrudCrontrollerTests.java
+++ b/middle-tier/src/test/java/com/marklogic/envision/controllers/CrudCrontrollerTests.java
@@ -18,15 +18,16 @@ public class CrudCrontrollerTests extends AbstractMvcTest {
 	ModelService modelService;
 
 	@BeforeEach
-	void setup() throws IOException {
+	public void setup() throws IOException {
+		envisionConfig.setMultiTenant(true);
+		super.setup();
+
 		removeUser(ACCOUNT_NAME);
 		removeUser(ACCOUNT_NAME2);
 		clearStagingFinalAndJobDatabases();
 
-		envisionConfig.setMultiTenant(true);
 		registerAccount();
 		registerAccount(ACCOUNT_NAME2, ACCOUNT_PASSWORD, "pii-reader");
-		installEnvisionModules();
 
 		HubClient hubClient = getNonAdminHubClient();
 		modelService.saveModel(hubClient, getResourceStream("entities/redactedName.json"));

--- a/middle-tier/src/test/java/com/marklogic/envision/controllers/EntitiesControllerTests.java
+++ b/middle-tier/src/test/java/com/marklogic/envision/controllers/EntitiesControllerTests.java
@@ -25,8 +25,10 @@ public class EntitiesControllerTests extends AbstractMvcTest {
 	ModelService modelService;
 
 	@BeforeEach
-	void setup() throws IOException {
+	public void setup() throws IOException {
+		clearStagingFinalAndJobDatabases();
 		envisionConfig.setMultiTenant(true);
+		super.setup();
 		HubClient hubClient = getNonAdminHubClient();
 		modelService.saveModel(hubClient, getResourceStream("models/model.json"));
 	}

--- a/middle-tier/src/test/java/com/marklogic/envision/controllers/ExploreControllerTests.java
+++ b/middle-tier/src/test/java/com/marklogic/envision/controllers/ExploreControllerTests.java
@@ -35,14 +35,13 @@ public class ExploreControllerTests extends AbstractMvcTest {
 	ModelService modelService;
 
 	@BeforeEach
-	void setup() throws IOException {
-		logout();
+	public void setup() throws IOException {
+		super.setup();
 
 		removeUser(ACCOUNT_NAME);
 		removeUser(ACCOUNT_NAME2);
 		clearStagingFinalAndJobDatabases();
 		clearDatabases(HubConfig.DEFAULT_STAGING_SCHEMAS_DB_NAME, HubConfig.DEFAULT_FINAL_SCHEMAS_DB_NAME);
-		installEnvisionModules();
 
 		registerAccount();
 		registerAccount(ACCOUNT_NAME2, ACCOUNT_PASSWORD);

--- a/middle-tier/src/test/java/com/marklogic/envision/controllers/ExportControllerTests.java
+++ b/middle-tier/src/test/java/com/marklogic/envision/controllers/ExportControllerTests.java
@@ -39,15 +39,13 @@ public class ExportControllerTests extends AbstractMvcTest {
 	ExportService exportService;
 
 	@BeforeEach
-	void setup() throws IOException {
-		logout();
+	public void setup() throws IOException {
+		envisionConfig.setMultiTenant(true);
+		super.setup();
 
 		removeUser(ACCOUNT_NAME);
 		removeUser(ACCOUNT_NAME2);
 		clearStagingFinalAndJobDatabases();
-
-		envisionConfig.setMultiTenant(true);
-		installEnvisionModules();
 
 		registerAccount();
 		registerAccount(ACCOUNT_NAME2, ACCOUNT_PASSWORD);
@@ -62,6 +60,7 @@ public class ExportControllerTests extends AbstractMvcTest {
 		for (int i = 100; i < 300; i++) {
 			installDoc(hc.getFinalClient(), "entities/exportMe2.xml", "/col2/doc-" + i + ".xml", "Department");
 		}
+		deleteCollection(getAdminHubClient().getFinalClient(), ExportService.EXPORT_INFO_COLLECTION);
 	}
 
 	@AfterEach

--- a/middle-tier/src/test/java/com/marklogic/envision/controllers/FlowsControllerTests.java
+++ b/middle-tier/src/test/java/com/marklogic/envision/controllers/FlowsControllerTests.java
@@ -46,14 +46,11 @@ public class FlowsControllerTests extends AbstractMvcTest {
 	ModelService modelService;
 
 	@BeforeEach
-	void setup() throws IOException {
-		logout();
-
-		removeUser(ACCOUNT_NAME);
+	public void setup() throws IOException {
 		envisionConfig.setMultiTenant(true);
+		super.setup();
+		removeUser(ACCOUNT_NAME);
 		clearStagingFinalAndJobDatabases();
-		installEnvisionModules();
-		installHubModules();
 
 		registerAccount();
 	}

--- a/middle-tier/src/test/java/com/marklogic/envision/controllers/MasteringControllerTests.java
+++ b/middle-tier/src/test/java/com/marklogic/envision/controllers/MasteringControllerTests.java
@@ -33,11 +33,11 @@ public class MasteringControllerTests extends AbstractMvcTest {
 	ModelService modelService;
 
 	@BeforeEach
-	void setup() throws IOException {
-		logout();
+	public void setup() throws IOException {
+		super.setup();
+
 		removeUser(ACCOUNT_NAME);
 		clearStagingFinalAndJobDatabases();
-		installEnvisionModules();
 
 		registerAccount();
 

--- a/middle-tier/src/test/java/com/marklogic/envision/controllers/ModelControllerTests.java
+++ b/middle-tier/src/test/java/com/marklogic/envision/controllers/ModelControllerTests.java
@@ -63,8 +63,8 @@ public class ModelControllerTests extends AbstractMvcTest {
 	}
 
 	@BeforeEach
-	void setup() throws IOException {
-		logout();
+	public void setup() throws IOException {
+		super.setup();
 
 		// remove models
 		removeModelFiles(false, null);
@@ -80,7 +80,6 @@ public class ModelControllerTests extends AbstractMvcTest {
 		removeUser(ACCOUNT_NAME);
 		removeUser(ACCOUNT_NAME2);
 		clearStagingFinalAndJobDatabases();
-		installEnvisionModules();
 	}
 
 	@Test

--- a/middle-tier/src/test/java/com/marklogic/envision/controllers/R2MControllerTests.java
+++ b/middle-tier/src/test/java/com/marklogic/envision/controllers/R2MControllerTests.java
@@ -7,6 +7,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.mock.web.MockMultipartFile;
 
+import java.io.IOException;
+
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -17,12 +19,11 @@ public class R2MControllerTests extends AbstractMvcTest {
 	R2MService r2mService;
 
 	@BeforeEach
-	void setup() {
-		logout();
+	public void setup() throws IOException {
+		super.setup();
 
 		removeUser(ACCOUNT_NAME);
 		clearStagingFinalAndJobDatabases();
-		installEnvisionModules();
 	}
 
 	@Test

--- a/middle-tier/src/test/java/com/marklogic/envision/controllers/SystemControllerTests.java
+++ b/middle-tier/src/test/java/com/marklogic/envision/controllers/SystemControllerTests.java
@@ -14,12 +14,11 @@ public class SystemControllerTests extends AbstractMvcTest {
 	private static final String DELETE_COLLECTIONS_URL = "/api/system/deleteCollection";
 
 	@BeforeEach
-	void setup() throws IOException {
-		logout();
+	public void setup() throws IOException {
+		super.setup();
 
 		removeUser(ACCOUNT_NAME);
 		clearStagingFinalAndJobDatabases();
-		installEnvisionModules();
 	}
 
 	@Test

--- a/middle-tier/src/test/java/com/marklogic/envision/controllers/TriplesControllerTests.java
+++ b/middle-tier/src/test/java/com/marklogic/envision/controllers/TriplesControllerTests.java
@@ -20,12 +20,11 @@ public class TriplesControllerTests extends AbstractMvcTest {
 	ModelService modelService;
 
 	@BeforeEach
-	void setup() throws IOException {
-		logout();
+	public void setup() throws IOException {
+		super.setup();
 
 		removeUser(ACCOUNT_NAME);
 		clearStagingFinalAndJobDatabases();
-		installEnvisionModules();
 
 		registerAccount();
 	}

--- a/middle-tier/src/test/java/com/marklogic/envision/controllers/UploadControllerTests.java
+++ b/middle-tier/src/test/java/com/marklogic/envision/controllers/UploadControllerTests.java
@@ -6,6 +6,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.mock.web.MockMultipartFile;
 
+import java.io.IOException;
+
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -16,12 +18,11 @@ public class UploadControllerTests extends AbstractMvcTest {
 	UploadService uploadService;
 
 	@BeforeEach
-	void setup() {
-		logout();
+	public void setup() throws IOException {
+		super.setup();
 
 		removeUser(ACCOUNT_NAME);
 		clearStagingFinalAndJobDatabases();
-		installEnvisionModules();
 	}
 
 	@Test

--- a/middle-tier/src/test/java/com/marklogic/envision/useCases/TestExplore.java
+++ b/middle-tier/src/test/java/com/marklogic/envision/useCases/TestExplore.java
@@ -21,16 +21,13 @@ public class TestExplore extends AbstractMvcTest {
 	ModelService modelService;
 
 	@BeforeEach
-	void setup() throws IOException, InterruptedException {
-		logout();
+	public void setup() throws IOException {
+		envisionConfig.setMultiTenant(true);
+		super.setup();
 
 		removeUser(ACCOUNT_NAME);
 		removeUser(ACCOUNT_NAME2);
 		clearStagingFinalAndJobDatabases();
-
-		envisionConfig.setMultiTenant(true);
-
-		installEnvisionModules();
 
 		registerAccount();
 		registerAccount(ACCOUNT_NAME2, ACCOUNT_PASSWORD);


### PR DESCRIPTION
Refactoring the tests to ensure the envision modules are installed before each test is run. 

Also, I added some logic to reduce the number of times the modules are installed when running the whole set of tests, cutting down on the total runtime.